### PR TITLE
chore: add node_modules and package-lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-01/.gitignore
+++ b/December-01/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-02/.gitignore
+++ b/December-02/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-03/.gitignore
+++ b/December-03/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-04/.gitignore
+++ b/December-04/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-05/.gitignore
+++ b/December-05/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-06/.gitignore
+++ b/December-06/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-07/.gitignore
+++ b/December-07/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-08/.gitignore
+++ b/December-08/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-09/.gitignore
+++ b/December-09/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-10/.gitignore
+++ b/December-10/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-11/.gitignore
+++ b/December-11/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-12/.gitignore
+++ b/December-12/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-13/.gitignore
+++ b/December-13/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-14/.gitignore
+++ b/December-14/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-15/.gitignore
+++ b/December-15/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-16/.gitignore
+++ b/December-16/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-17/.gitignore
+++ b/December-17/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-18/.gitignore
+++ b/December-18/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-19/.gitignore
+++ b/December-19/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-20/.gitignore
+++ b/December-20/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-21/.gitignore
+++ b/December-21/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-22/.gitignore
+++ b/December-22/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-23/.gitignore
+++ b/December-23/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-24/.gitignore
+++ b/December-24/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-25/.gitignore
+++ b/December-25/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-26/.gitignore
+++ b/December-26/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-27/.gitignore
+++ b/December-27/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-28/.gitignore
+++ b/December-28/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-29/.gitignore
+++ b/December-29/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-30/.gitignore
+++ b/December-30/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/

--- a/December-31/.gitignore
+++ b/December-31/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 # C extensions
 *.so
 
+# node.js
+/node_modules
+package-lock.json
+
 # Distribution / packaging
 .Python
 build/


### PR DESCRIPTION
resolves #14 issue that I had raised regarding node.js.  This PR allows people undertaking the challenge to push their commits without pushing the node_modules and the lock file. 